### PR TITLE
Switch to v2 r-lib/actions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -205,7 +205,7 @@ jobs:
           timezoneWindows: ${{ matrix.config.timezone-name }}
 
       - name: Check without doc
-        if: ${{!matrix.config.vignettes}} && matrix.config.os-name == 'windows'
+        if: !matrix.config.vignettes && matrix.config.os-name == 'windows'
         uses: r-lib/actions/check-r-package@v2
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
@@ -217,7 +217,7 @@ jobs:
           FULL_TEST_SUITE: 1
 
       - name: Check without doc
-        if: ${{!matrix.config.vignettes}} && matrix.config.os-name != 'windows'
+        if: matrix.config.os-name != 'windows' && matrix.config.vignettes
         uses: r-lib/actions/check-r-package@v2
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -205,7 +205,7 @@ jobs:
           timezoneWindows: ${{ matrix.config.timezone-name }}
 
       - name: Check without doc
-        if: !matrix.config.vignettes && matrix.config.os-name == 'windows'
+        if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
         uses: r-lib/actions/check-r-package@v2
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
@@ -217,7 +217,7 @@ jobs:
           FULL_TEST_SUITE: 1
 
       - name: Check without doc
-        if: matrix.config.os-name != 'windows' && matrix.config.vignettes
+        if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
         uses: r-lib/actions/check-r-package@v2
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -210,8 +210,8 @@ jobs:
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
           build_args: 'c("--no-build-vignettes")'
-          error-on: error
-          # check_dir: check # default provided by check-r-package
+          error-on: '"error"'
+          # check_dir: '"check"' # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
@@ -222,8 +222,8 @@ jobs:
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
           build_args: 'c("--no-build-vignettes")'
-          error-on: error
-          # check_dir: check # default provided by check-r-package
+          error-on: '"error"'
+          # check_dir: '"check"' # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
@@ -249,8 +249,8 @@ jobs:
         with:
           args: 'c("--as-cran")'
           build_args: 'c("--compact-vignettes=gs+qpdf")'
-          # error-on: warning # default provided by check-r-package
-          # check_dir: check # default provided by check-r-package
+          # error-on: '"warning"' # default provided by check-r-package
+          # check_dir: '"check"' # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -108,13 +108,6 @@ jobs:
         if: runner.os == 'Windows'
         run: java -version
 
-      # - name: Query dependencies
-      #   run: |
-      #     install.packages('remotes', repos=getOption('repos')[['CRAN']])
-      #     saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      #   shell: Rscript {0}
-
       - name: Install and cache dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -122,14 +115,6 @@ jobs:
             any::covr
             any::rcmdcheck
             any::remotes
-
-      # - name: Cache R packages
-      #   if: runner.os != 'Windows'
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.R_LIBS_USER }}
-      #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}${{matrix.config.pkgrepo}}
-      #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install tinytex
         if: matrix.config.vignettes
@@ -148,26 +133,10 @@ jobs:
           tinytex:::install_yihui_pkgs()
         shell: Rscript {0}
 
-      # - name: Install system dependencies
-      #   if: runner.os == 'Linux'
-      #   run: |
-      #     sudo apt-get install libcurl4-openssl-dev
-      #     while read -r cmd
-      #     do
-      #       eval sudo $cmd
-      #     done < <(Rscript -e 'writeLines(remotes::system_requirements("${{ matrix.config.os-name }}", "${{ matrix.config.os-version }}"))')
-      
       - name: Install PDF system dependencies
         if: runner.os == 'Linux' && matrix.config.vignettes
         run: | 
           sudo apt-get install -y qpdf ghostscript
-
-      # - name: Install dependencies
-      #   run: |
-      #     remotes::install_cran("covr")
-      #     remotes::install_deps(dependencies = TRUE, repos=getOption('repos')[['RSPM']])
-      #     remotes::install_cran("rcmdcheck")
-      #   shell: Rscript {0}
 
       - name: Session info
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Install extra Tex packages
         if: matrix.config.vignettes
         run: |
-          pak::pkg_install('tinytex', repos=getOption('repos')[['RSPM']])
+          pak::pkg_install('tinytex')
           library(tinytex)
           tlmgr_install('datetime') 
           tlmgr_install('inputenc')

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -120,20 +120,27 @@ jobs:
         if: runner.os == 'Windows'
         run: java -version
 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes', repos=getOption('repos')[['CRAN']])
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
+      # - name: Query dependencies
+      #   run: |
+      #     install.packages('remotes', repos=getOption('repos')[['CRAN']])
+      #     saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+      #   shell: Rscript {0}
 
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - name: Install and cache dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}${{matrix.config.pkgrepo}}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: |
+            any::covr
+            any::rcmdcheck
+
+      # - name: Cache R packages
+      #   if: runner.os != 'Windows'
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.R_LIBS_USER }}
+      #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}${{matrix.config.pkgrepo}}
+      #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install tinytex
         if: matrix.config.vignettes
@@ -166,12 +173,12 @@ jobs:
         run: | 
           sudo apt-get install -y qpdf ghostscript
 
-      - name: Install dependencies
-        run: |
-          remotes::install_cran("covr")
-          remotes::install_deps(dependencies = TRUE, repos=getOption('repos')[['RSPM']])
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
+      # - name: Install dependencies
+      #   run: |
+      #     remotes::install_cran("covr")
+      #     remotes::install_deps(dependencies = TRUE, repos=getOption('repos')[['RSPM']])
+      #     remotes::install_cran("rcmdcheck")
+      #   shell: Rscript {0}
 
       - name: Session info
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -161,66 +161,66 @@ jobs:
         with:
           timezoneWindows: ${{ matrix.config.timezone-name }}
 
-      # - name: Check without doc
-      #   if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
-      #   uses: r-lib/actions/check-r-package@v2
-      #   with:
-      #     args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
-      #     build_args: 'c("--no-build-vignettes")'
-      #     error-on: '"error"'
-      #     # check_dir: '"check"' # default provided by check-r-package
-      #   env:
-      #     # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
-      #     FULL_TEST_SUITE: 1
-      # 
-      # - name: Check without doc
-      #   if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
-      #   uses: r-lib/actions/check-r-package@v2
-      #   with:
-      #     args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
-      #     build_args: 'c("--no-build-vignettes")'
-      #     error-on: '"error"'
-      #     # check_dir: '"check"' # default provided by check-r-package
-      #   env:
-      #     # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
-      #     FULL_TEST_SUITE: 1
+      - name: Check without doc
+        if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
+          build_args: 'c("--no-build-vignettes")'
+          error-on: '"error"'
+          # check_dir: '"check"' # default provided by check-r-package
+        env:
+          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
+          FULL_TEST_SUITE: 1
 
       - name: Check without doc
-        if: ${{!matrix.config.vignettes}}
+        if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
+          build_args: 'c("--no-build-vignettes")'
+          error-on: '"error"'
+          # check_dir: '"check"' # default provided by check-r-package
         env:
-          _R_CHECK_CRAN_INCOMING_: false
+          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
-        run: |-
-            paste0("java home in R: ", Sys.getenv("JAVA_HOME"))
-            check_args <- if("${{matrix.config.os-name}}" == "windows") {
-              c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")
-            } else {
-              c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")
-            }
-            rcmdcheck::rcmdcheck(args = check_args, build_args=c("--no-build-vignettes"), error_on = "error", check_dir = "check")
-        shell: Rscript {0}
-      
-      # - name: Check with doc
-      #   if: matrix.config.vignettes
-      #   uses: r-lib/actions/check-r-package@v2
-      #   with:
-      #     args: 'c("--as-cran")'
-      #     build_args: 'c("--compact-vignettes=gs+qpdf")'
-      #     # error-on: '"warning"' # default provided by check-r-package
-      #     # check_dir: '"check"' # default provided by check-r-package
-      #   env:
-      #     # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
-      #     FULL_TEST_SUITE: 1
 
+      # - name: Check without doc
+      #   if: ${{!matrix.config.vignettes}}
+      #   env:
+      #     _R_CHECK_CRAN_INCOMING_: false
+      #     FULL_TEST_SUITE: 1
+      #   run: |-
+      #       paste0("java home in R: ", Sys.getenv("JAVA_HOME"))
+      #       check_args <- if("${{matrix.config.os-name}}" == "windows") {
+      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")
+      #       } else {
+      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")
+      #       }
+      #       rcmdcheck::rcmdcheck(args = check_args, build_args=c("--no-build-vignettes"), error_on = "error", check_dir = "check")
+      #   shell: Rscript {0}
+      
       - name: Check with doc
         if: matrix.config.vignettes
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--as-cran")'
+          build_args: 'c("--compact-vignettes=gs+qpdf")'
+          # error-on: '"warning"' # default provided by check-r-package
+          # check_dir: '"check"' # default provided by check-r-package
         env:
-          _R_CHECK_CRAN_INCOMING_: false
+          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
-        run: >-
-          rcmdcheck::rcmdcheck(args = c("--as-cran"),
-          build_args=c("--compact-vignettes=gs+qpdf"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
+
+      # - name: Check with doc
+      #   if: matrix.config.vignettes
+      #   env:
+      #     _R_CHECK_CRAN_INCOMING_: false
+      #     FULL_TEST_SUITE: 1
+      #   run: >-
+      #     rcmdcheck::rcmdcheck(args = c("--as-cran"),
+      #     build_args=c("--compact-vignettes=gs+qpdf"), error_on = "warning", check_dir = "check")
+      #   shell: Rscript {0}
 
       - name: run complete test suite # some tests are not run in r check, as test xls(x) files are Rbuild-ignored
         if: always()

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -207,10 +207,10 @@ jobs:
       - name: Check without doc
         if: ${{!matrix.config.vignettes}} && matrix.config.os-name == 'windows'
         uses: r-lib/actions/check-r-package@v2
-        args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
-        build_args: 'c("--no-build-vignettes")'
-        error-on: "error"
-        # check_dir: "check" # default provided by check-r-package
+          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
+          build_args: 'c("--no-build-vignettes")'
+          error-on: "error"
+          # check_dir: "check" # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
@@ -218,10 +218,10 @@ jobs:
       - name: Check without doc
         if: ${{!matrix.config.vignettes}} && matrix.config.os-name != 'windows'
         uses: r-lib/actions/check-r-package@v2
-        args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
-        build_args: 'c("--no-build-vignettes")'
-        error-on: "error"
-        # check_dir: "check" # default provided by check-r-package
+          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
+          build_args: 'c("--no-build-vignettes")'
+          error-on: "error"
+          # check_dir: "check" # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
@@ -244,10 +244,10 @@ jobs:
       - name: Check with doc
         if: matrix.config.vignettes
         uses: r-lib/actions/check-r-package@v2
-        args: 'c("--as-cran")'
-        build_args: 'c("--compact-vignettes=gs+qpdf")'
-        # error-on: "warning" # default provided by check-r-package
-        # check_dir: "check" # default provided by check-r-package
+          args: 'c("--as-cran")'
+          build_args: 'c("--compact-vignettes=gs+qpdf")'
+          # error-on: "warning" # default provided by check-r-package
+          # check_dir: "check" # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -165,21 +165,21 @@ jobs:
         if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
         uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
+          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch"["${{matrix.config.os-name}}" == "windows"])'
           build_args: 'c("--no-build-vignettes")'
           error-on: '"error"'
         env:
           FULL_TEST_SUITE: 1
 
-      - name: Check without doc
-        if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
-          build_args: 'c("--no-build-vignettes")'
-          error-on: '"error"'
-        env:
-          FULL_TEST_SUITE: 1
+      # - name: Check without doc
+      #   if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
+      #   uses: r-lib/actions/check-r-package@v2
+      #   with:
+      #     args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
+      #     build_args: 'c("--no-build-vignettes")'
+      #     error-on: '"error"'
+      #   env:
+      #     FULL_TEST_SUITE: 1
 
       # - name: Check without doc
       #   if: ${{!matrix.config.vignettes}}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -173,31 +173,6 @@ jobs:
         env:
           FULL_TEST_SUITE: 1
 
-      # - name: Check without doc
-      #   if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
-      #   uses: r-lib/actions/check-r-package@v2
-      #   with:
-      #     args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
-      #     build_args: 'c("--no-build-vignettes")'
-      #     error-on: '"error"'
-      #   env:
-      #     FULL_TEST_SUITE: 1
-
-      # - name: Check without doc
-      #   if: ${{!matrix.config.vignettes}}
-      #   env:
-      #     _R_CHECK_CRAN_INCOMING_: false
-      #     FULL_TEST_SUITE: 1
-      #   run: |-
-      #       paste0("java home in R: ", Sys.getenv("JAVA_HOME"))
-      #       check_args <- if("${{matrix.config.os-name}}" == "windows") {
-      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")
-      #       } else {
-      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")
-      #       }
-      #       rcmdcheck::rcmdcheck(args = check_args, build_args=c("--no-build-vignettes"), error_on = "error", check_dir = "check")
-      #   shell: Rscript {0}
-      
       - name: Check with doc
         if: matrix.config.vignettes
         uses: r-lib/actions/check-r-package@v2
@@ -206,16 +181,6 @@ jobs:
           build_args: 'c("--compact-vignettes=gs+qpdf")'
         env:
           FULL_TEST_SUITE: 1
-
-      # - name: Check with doc
-      #   if: matrix.config.vignettes
-      #   env:
-      #     _R_CHECK_CRAN_INCOMING_: false
-      #     FULL_TEST_SUITE: 1
-      #   run: >-
-      #     rcmdcheck::rcmdcheck(args = c("--as-cran"),
-      #     build_args=c("--compact-vignettes=gs+qpdf"), error_on = "warning", check_dir = "check")
-      #   shell: Rscript {0}
 
       - name: run complete test suite # some tests are not run in r check, as test xls(x) files are Rbuild-ignored
         if: always()

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -97,7 +97,7 @@ jobs:
         shell: Rscript {0}
 
       - name: test additional java env var
-        if: matrix.config.java > 8 # covering with / without the var being present
+        if: ${{!matrix.config.vignettes}} # covering with / without the var being present
         run: echo 'JAVA_TOOL_OPTIONS="-Dlog4j.formatMsgNoLookups=true"' >> $GITHUB_ENV
 
       - name: run javareconf # Yes it actually needs JAVA_HOME=$JAVA_HOME, doesn't use actual env vars (!)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,6 +23,7 @@ jobs:
       ${{ matrix.config.os-name }}-${{ matrix.config.os-version }}
       R ${{ matrix.config.r-version}} - java ${{ matrix.config.java}}
     strategy:
+      fail-fast: false
       matrix:
         config: 
           - os-name: ubuntu # windows-2019, macos-10.15]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -148,14 +148,14 @@ jobs:
           tinytex:::install_yihui_pkgs()
         shell: Rscript {0}
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install libcurl4-openssl-dev
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("${{ matrix.config.os-name }}", "${{ matrix.config.os-version }}"))')
+      # - name: Install system dependencies
+      #   if: runner.os == 'Linux'
+      #   run: |
+      #     sudo apt-get install libcurl4-openssl-dev
+      #     while read -r cmd
+      #     do
+      #       eval sudo $cmd
+      #     done < <(Rscript -e 'writeLines(remotes::system_requirements("${{ matrix.config.os-name }}", "${{ matrix.config.os-version }}"))')
       
       - name: Install PDF system dependencies
         if: runner.os == 'Linux' && matrix.config.vignettes

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -161,66 +161,66 @@ jobs:
         with:
           timezoneWindows: ${{ matrix.config.timezone-name }}
 
-      - name: Check without doc
-        if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
-          build_args: 'c("--no-build-vignettes")'
-          error-on: '"error"'
-          # check_dir: '"check"' # default provided by check-r-package
-        env:
-          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
-          FULL_TEST_SUITE: 1
-
-      - name: Check without doc
-        if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
-          build_args: 'c("--no-build-vignettes")'
-          error-on: '"error"'
-          # check_dir: '"check"' # default provided by check-r-package
-        env:
-          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
-          FULL_TEST_SUITE: 1
-
       # - name: Check without doc
-      #   if: ${{!matrix.config.vignettes}}
+      #   if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
+      #   uses: r-lib/actions/check-r-package@v2
+      #   with:
+      #     args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
+      #     build_args: 'c("--no-build-vignettes")'
+      #     error-on: '"error"'
+      #     # check_dir: '"check"' # default provided by check-r-package
       #   env:
-      #     _R_CHECK_CRAN_INCOMING_: false
+      #     # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
       #     FULL_TEST_SUITE: 1
-      #   run: |-
-      #       paste0("java home in R: ", Sys.getenv("JAVA_HOME"))
-      #       check_args <- if("${{matrix.config.os-name}}" == "windows") {
-      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")
-      #       } else {
-      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")
-      #       }
-      #       rcmdcheck::rcmdcheck(args = check_args, build_args=c("--no-build-vignettes"), error_on = "error", check_dir = "check")
-      #   shell: Rscript {0}
-      
-      - name: Check with doc
-        if: matrix.config.vignettes
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          args: 'c("--as-cran")'
-          build_args: 'c("--compact-vignettes=gs+qpdf")'
-          # error-on: '"warning"' # default provided by check-r-package
-          # check_dir: '"check"' # default provided by check-r-package
-        env:
-          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
-          FULL_TEST_SUITE: 1
+      # 
+      # - name: Check without doc
+      #   if: ${{!matrix.config.vignettes && matrix.config.os-name != 'windows'}}
+      #   uses: r-lib/actions/check-r-package@v2
+      #   with:
+      #     args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
+      #     build_args: 'c("--no-build-vignettes")'
+      #     error-on: '"error"'
+      #     # check_dir: '"check"' # default provided by check-r-package
+      #   env:
+      #     # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
+      #     FULL_TEST_SUITE: 1
 
+      - name: Check without doc
+        if: ${{!matrix.config.vignettes}}
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+          FULL_TEST_SUITE: 1
+        run: |-
+            paste0("java home in R: ", Sys.getenv("JAVA_HOME"))
+            check_args <- if("${{matrix.config.os-name}}" == "windows") {
+              c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")
+            } else {
+              c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")
+            }
+            rcmdcheck::rcmdcheck(args = check_args, build_args=c("--no-build-vignettes"), error_on = "error", check_dir = "check")
+        shell: Rscript {0}
+      
       # - name: Check with doc
       #   if: matrix.config.vignettes
+      #   uses: r-lib/actions/check-r-package@v2
+      #   with:
+      #     args: 'c("--as-cran")'
+      #     build_args: 'c("--compact-vignettes=gs+qpdf")'
+      #     # error-on: '"warning"' # default provided by check-r-package
+      #     # check_dir: '"check"' # default provided by check-r-package
       #   env:
-      #     _R_CHECK_CRAN_INCOMING_: false
+      #     # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
       #     FULL_TEST_SUITE: 1
-      #   run: >- 
-      #     rcmdcheck::rcmdcheck(args = c("--as-cran"), 
-      #     build_args=c("--compact-vignettes=gs+qpdf"), error_on = "warning", check_dir = "check")
-      #   shell: Rscript {0}
+
+      - name: Check with doc
+        if: matrix.config.vignettes
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+          FULL_TEST_SUITE: 1
+        run: >-
+          rcmdcheck::rcmdcheck(args = c("--as-cran"),
+          build_args=c("--compact-vignettes=gs+qpdf"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
 
       - name: run complete test suite # some tests are not run in r check, as test xls(x) files are Rbuild-ignored
         if: always()

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,6 +38,7 @@ jobs:
             r-version: release
             java: 11
             vignettes: true
+            xlc-repo: https://jcenter.bintray.com
             timezone-name: Asia/Kathmandu
           - os-name: ubuntu # windows-2019, macos-10.15]
             os-version: "18.04"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -3,7 +3,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 #
-# See https://github.com/r-lib/actions/tree/master/examples#readme for
+# See https://github.com/r-lib/actions/tree/v2/examples#readme for
 # additional example workflows available for the R community.
 
 name: R
@@ -94,7 +94,7 @@ jobs:
         if: matrix.config.os-name != 'macos'
 
       - name: Set up R ${{ matrix.config.r-version }}
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install tinytex
         if: matrix.config.vignettes
-        uses: r-lib/actions/setup-tinytex@v1
+        uses: r-lib/actions/setup-tinytex@v2
 
       - name: Install extra Tex packages
         if: matrix.config.vignettes

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -205,29 +205,62 @@ jobs:
           timezoneWindows: ${{ matrix.config.timezone-name }}
 
       - name: Check without doc
-        if: ${{!matrix.config.vignettes}}
+        if: ${{!matrix.config.vignettes}} && matrix.config.os-name == 'windows'
+        uses: r-lib/actions/check-r-package@v2
+        args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
+        build_args: 'c("--no-build-vignettes")'
+        error-on: "error"
+        # check_dir: "check" # default provided by check-r-package
         env:
-          _R_CHECK_CRAN_INCOMING_: false
+          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
-        run: |-
-            paste0("java home in R: ", Sys.getenv("JAVA_HOME"))
-            check_args <- if("${{matrix.config.os-name}}" == "windows") {
-              c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")
-            } else {
-              c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")
-            }
-            rcmdcheck::rcmdcheck(args = check_args, build_args=c("--no-build-vignettes"), error_on = "error", check_dir = "check")
-        shell: Rscript {0}
 
+      - name: Check without doc
+        if: ${{!matrix.config.vignettes}} && matrix.config.os-name != 'windows'
+        uses: r-lib/actions/check-r-package@v2
+        args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
+        build_args: 'c("--no-build-vignettes")'
+        error-on: "error"
+        # check_dir: "check" # default provided by check-r-package
+        env:
+          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
+          FULL_TEST_SUITE: 1
+
+      # - name: Check without doc
+      #   if: ${{!matrix.config.vignettes}}
+      #   env:
+      #     _R_CHECK_CRAN_INCOMING_: false
+      #     FULL_TEST_SUITE: 1
+      #   run: |-
+      #       paste0("java home in R: ", Sys.getenv("JAVA_HOME"))
+      #       check_args <- if("${{matrix.config.os-name}}" == "windows") {
+      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")
+      #       } else {
+      #         c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")
+      #       }
+      #       rcmdcheck::rcmdcheck(args = check_args, build_args=c("--no-build-vignettes"), error_on = "error", check_dir = "check")
+      #   shell: Rscript {0}
+      
       - name: Check with doc
         if: matrix.config.vignettes
+        uses: r-lib/actions/check-r-package@v2
+        args: 'c("--as-cran")'
+        build_args: 'c("--compact-vignettes=gs+qpdf")'
+        # error-on: "warning" # default provided by check-r-package
+        # check_dir: "check" # default provided by check-r-package
         env:
-          _R_CHECK_CRAN_INCOMING_: false
+          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
-        run: >- 
-          rcmdcheck::rcmdcheck(args = c("--as-cran"), 
-          build_args=c("--compact-vignettes=gs+qpdf"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
+
+      # - name: Check with doc
+      #   if: matrix.config.vignettes
+      #   env:
+      #     _R_CHECK_CRAN_INCOMING_: false
+      #     FULL_TEST_SUITE: 1
+      #   run: >- 
+      #     rcmdcheck::rcmdcheck(args = c("--as-cran"), 
+      #     build_args=c("--compact-vignettes=gs+qpdf"), error_on = "warning", check_dir = "check")
+      #   shell: Rscript {0}
 
       - name: run complete test suite # some tests are not run in r check, as test xls(x) files are Rbuild-ignored
         if: always()

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -165,9 +165,8 @@ jobs:
         if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
         uses: r-lib/actions/check-r-package@v2
         with:
-          args: >-
-            'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no",
-            "--no-multiarch"["${{matrix.config.os-name}}" == "windows"])'
+          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no",
+                   "--no-multiarch"["${{matrix.config.os-name}}" == "windows"])'
           build_args: 'c("--no-build-vignettes")'
           error-on: '"error"'
         env:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -98,6 +98,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
+          use-public-rspm: true
 
       - name: print effective R version
         run: version

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -167,7 +167,7 @@ jobs:
           timezoneWindows: ${{ matrix.config.timezone-name }}
 
       - name: Check without doc
-        if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
+        if: ${{!matrix.config.vignettes}}
         uses: r-lib/actions/check-r-package@v2
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no",

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,14 +51,6 @@ jobs:
             r-version: release
             # java: 13
             vignettes: false
-          - os-name: ubuntu 
-            os-version: "18.04"
-            r-version: 3.2.5
-            java: 8
-            vignettes: false
-            xlc-repo: https://jcenter.bintray.com
-            timezone-name: Canada/Newfoundland
-            pkgrepo: https://cran.microsoft.com/snapshot/2017-12-31/
           - os-name: windows # windows-2019, macos-10.15]
             os-version: "2019"
             r-version: release
@@ -103,10 +95,6 @@ jobs:
       - name: print effective R version
         run: version
         shell: Rscript {0}
-      
-      - name: test additional java env var
-        if: matrix.config.r-version == '3.2.5' # covering with / without the var being present
-        run: echo 'JAVA_TOOL_OPTIONS="-Dlog4j.formatMsgNoLookups=true"' >> $GITHUB_ENV
 
       - name: run javareconf # Yes it actually needs JAVA_HOME=$JAVA_HOME, doesn't use actual env vars (!)
         if: runner.os != 'Windows'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -207,6 +207,7 @@ jobs:
       - name: Check without doc
         if: ${{!matrix.config.vignettes}} && matrix.config.os-name == 'windows'
         uses: r-lib/actions/check-r-package@v2
+        with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
           build_args: 'c("--no-build-vignettes")'
           error-on: "error"
@@ -218,6 +219,7 @@ jobs:
       - name: Check without doc
         if: ${{!matrix.config.vignettes}} && matrix.config.os-name != 'windows'
         uses: r-lib/actions/check-r-package@v2
+        with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
           build_args: 'c("--no-build-vignettes")'
           error-on: "error"
@@ -244,6 +246,7 @@ jobs:
       - name: Check with doc
         if: matrix.config.vignettes
         uses: r-lib/actions/check-r-package@v2
+        with:
           args: 'c("--as-cran")'
           build_args: 'c("--compact-vignettes=gs+qpdf")'
           # error-on: "warning" # default provided by check-r-package

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -97,7 +97,7 @@ jobs:
         shell: Rscript {0}
 
       - name: test additional java env var
-        if: matrix.config.r-version == release # covering with / without the var being present
+        if: matrix.config.java > 8 # covering with / without the var being present
         run: echo 'JAVA_TOOL_OPTIONS="-Dlog4j.formatMsgNoLookups=true"' >> $GITHUB_ENV
 
       - name: run javareconf # Yes it actually needs JAVA_HOME=$JAVA_HOME, doesn't use actual env vars (!)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -165,7 +165,7 @@ jobs:
         if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
         uses: r-lib/actions/check-r-package@v2
         with:
-          args: >
+          args: >-
             'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no",
             "--no-multiarch"["${{matrix.config.os-name}}" == "windows"])'
           build_args: 'c("--no-build-vignettes")'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -95,7 +95,7 @@ jobs:
         if: matrix.config.os-name != 'macos'
 
       - name: Set up R ${{ matrix.config.r-version }}
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Install extra Tex packages
         if: matrix.config.vignettes
         run: |
-          remotes::install_cran('tinytex', repos=getOption('repos')[['RSPM']])
+          pak::pkg_install('tinytex', repos=getOption('repos')[['RSPM']])
           library(tinytex)
           tlmgr_install('datetime') 
           tlmgr_install('inputenc')

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,7 +76,7 @@ jobs:
           java-version: ${{ matrix.config.java }}
           java-package: jdk
           architecture: x86
-        if: matrix.config.os-name != 'macos'
+        if: matrix.config.os-name != 'macos' && matrix.config.java != 11
       
       - name: Setup java (x64)
         uses: actions/setup-java@v1
@@ -84,7 +84,7 @@ jobs:
           java-version: ${{ matrix.config.java }}
           java-package: jdk
           architecture: x64
-        if: matrix.config.os-name != 'macos'
+        if: matrix.config.os-name != 'macos' && matrix.config.java != 11
 
       - name: Set up R ${{ matrix.config.r-version }}
         uses: r-lib/actions/setup-r@v2
@@ -100,8 +100,9 @@ jobs:
         if: ${{!matrix.config.vignettes}} # covering with / without the var being present
         run: echo 'JAVA_TOOL_OPTIONS="-Dlog4j.formatMsgNoLookups=true"' >> $GITHUB_ENV
 
+      # todo not sure if this is run again during "Install and cache dependencies" before rJava install
       - name: run javareconf # Yes it actually needs JAVA_HOME=$JAVA_HOME, doesn't use actual env vars (!)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.config.java != 11
         run: |
           java -version
           echo java_home:$JAVA_HOME

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -133,6 +133,7 @@ jobs:
           extra-packages: |
             any::covr
             any::rcmdcheck
+            any::remotes
 
       # - name: Cache R packages
       #   if: runner.os != 'Windows'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -96,6 +96,10 @@ jobs:
         run: version
         shell: Rscript {0}
 
+      - name: test additional java env var
+        if: matrix.config.r-version == release # covering with / without the var being present
+        run: echo 'JAVA_TOOL_OPTIONS="-Dlog4j.formatMsgNoLookups=true"' >> $GITHUB_ENV
+
       - name: run javareconf # Yes it actually needs JAVA_HOME=$JAVA_HOME, doesn't use actual env vars (!)
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,7 +38,6 @@ jobs:
             r-version: release
             java: 11
             vignettes: true
-            xlc-repo: https://jcenter.bintray.com
             timezone-name: Asia/Kathmandu
           - os-name: ubuntu # windows-2019, macos-10.15]
             os-version: "18.04"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -165,7 +165,9 @@ jobs:
         if: ${{!matrix.config.vignettes && matrix.config.os-name == 'windows'}}
         uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch"["${{matrix.config.os-name}}" == "windows"])'
+          args: >
+            'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no",
+            "--no-multiarch"["${{matrix.config.os-name}}" == "windows"])'
           build_args: 'c("--no-build-vignettes")'
           error-on: '"error"'
         env:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -210,8 +210,8 @@ jobs:
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
           build_args: 'c("--no-build-vignettes")'
-          error-on: "error"
-          # check_dir: "check" # default provided by check-r-package
+          error-on: error
+          # check_dir: check # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
@@ -222,8 +222,8 @@ jobs:
         with:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
           build_args: 'c("--no-build-vignettes")'
-          error-on: "error"
-          # check_dir: "check" # default provided by check-r-package
+          error-on: error
+          # check_dir: check # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
@@ -249,8 +249,8 @@ jobs:
         with:
           args: 'c("--as-cran")'
           build_args: 'c("--compact-vignettes=gs+qpdf")'
-          # error-on: "warning" # default provided by check-r-package
-          # check_dir: "check" # default provided by check-r-package
+          # error-on: warning # default provided by check-r-package
+          # check_dir: check # default provided by check-r-package
         env:
           # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -94,7 +94,7 @@ jobs:
         if: matrix.config.os-name != 'macos'
 
       - name: Set up R ${{ matrix.config.r-version }}
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r-version }}
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -168,9 +168,7 @@ jobs:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no", "--no-multiarch")'
           build_args: 'c("--no-build-vignettes")'
           error-on: '"error"'
-          # check_dir: '"check"' # default provided by check-r-package
         env:
-          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
 
       - name: Check without doc
@@ -180,9 +178,7 @@ jobs:
           args: 'c("--no-manual", "--no-vignettes", "--no-build-vignettes", "--check-subdirs=no")'
           build_args: 'c("--no-build-vignettes")'
           error-on: '"error"'
-          # check_dir: '"check"' # default provided by check-r-package
         env:
-          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
 
       # - name: Check without doc
@@ -206,10 +202,7 @@ jobs:
         with:
           args: 'c("--as-cran")'
           build_args: 'c("--compact-vignettes=gs+qpdf")'
-          # error-on: '"warning"' # default provided by check-r-package
-          # check_dir: '"check"' # default provided by check-r-package
         env:
-          # _R_CHECK_CRAN_INCOMING_: false # default provided by check-r-package
           FULL_TEST_SUITE: 1
 
       # - name: Check with doc

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -129,7 +129,6 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
-          windows-path-include-mingw: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -65,19 +65,6 @@ jobs:
         with:
           extra-packages: any::devtools
 
-      # - name: Query dependencies
-      #   run: |
-      #     install.packages('remotes')
-      #     saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      #   shell: Rscript {0}
-      # 
-      # - name: Install dependencies
-      #   run: |
-      #     remotes::install_deps(dependencies = TRUE)
-      #     remotes::install_cran("devtools")
-      #   shell: Rscript {0}
-
       - name: Session info
         run: |
           options(width = 100)

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -60,18 +60,23 @@ jobs:
       - name: effective java version # Yes it actually needs JAVA_HOME=$JAVA_HOME, doesn't use actual env vars (!)
         run: java -version
 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
+      - name: Install and cache dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::devtools
 
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("devtools")
-        shell: Rscript {0}
+      # - name: Query dependencies
+      #   run: |
+      #     install.packages('remotes')
+      #     saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+      #     writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+      #   shell: Rscript {0}
+      # 
+      # - name: Install dependencies
+      #   run: |
+      #     remotes::install_deps(dependencies = TRUE)
+      #     remotes::install_cran("devtools")
+      #   shell: Rscript {0}
 
       - name: Session info
         run: |

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r-version }}
 
-      - name: Install dependencies
+      - name: Install rJava dependency
         run: |
           install.packages('rJava')
         shell: Rscript {0}

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -46,6 +46,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
+          use-public-rspm: true
 
       - name: find out PATH changes
         run: | 
@@ -121,6 +122,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
+          use-public-rspm: true
 
       - name: Install rJava dependency
         run: |

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -46,7 +46,6 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
-          use-public-rspm: true
 
       - name: find out PATH changes
         run: | 
@@ -130,7 +129,6 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
-          use-public-rspm: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -46,6 +46,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
+          use-public-rspm: true
 
       - name: find out PATH changes
         run: | 
@@ -129,6 +130,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
+          use-public-rspm: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows-bin.yml
+++ b/.github/workflows/windows-bin.yml
@@ -3,7 +3,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 #
-# See https://github.com/r-lib/actions/tree/master/examples#readme for
+# See https://github.com/r-lib/actions/tree/v2/examples#readme for
 # additional example workflows available for the R community.
 
 name: windows-binary-test
@@ -43,7 +43,7 @@ jobs:
           architecture: x64
 
       - name: Set up R ${{ matrix.config.r-version }}
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
 
@@ -126,7 +126,7 @@ jobs:
           architecture: x64
 
       - name: Set up R ${{ matrix.config.r-version }}
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r-version }}
           windows-path-include-mingw: false


### PR DESCRIPTION
Switch to v2 r-lib/actions to use @v2 (these updates are not expected to cause any issues).

I changed fail-fast to false to better see what is going on. We can enable it again later if we want to.

I noticed that the R 3.2.5 job fails on the `Install dependencies` step by now (also on master) because the latest `cli` package requires `glue (≥ 1.6.0)`, which in turn requires `R (≥ 3.4)`. See e.g. https://github.com/miraisolutions/xlconnect/runs/5287672214?check_suite_focus=true#step:17:1242. Otherwise, they all pass with the current changes (see [commit](https://github.com/miraisolutions/xlconnect/pull/160/commits/ce7dc9177953dd10a5b01c1e2c5a2c392d9c4ec8)). **To be dealt with**

List of updates:
- `r-lib/actions/setup-r` is updated to use v2 instead of master (which would at some point anyway not point to v1 anymore).
- `windows-path-include-mingw` was removed since it is not supported since r-lib actions v2.1.0 anymore. This should be safe as the windows-binary-test workflow is based on the latest r release.
- Nothing changed on setup-tinytex since v1, so the update to v2 is safe.
- Consider adding `use-public-rspm: true` to `r-lib/actions/setup-r`. It looks like this speeds up ubuntu jobs, but slows down windows and mac jobs. For that reason I'll keep it only in `ci-tests.yml` for now.
- Switched to `r-lib/actions/setup-r-dependencies@v2` for the `windows-bin.yml` workflow, which made it considerably faster, even before the caching applied. Also renamed the step that installs rJava to be a bit more precise.
- Switched to `r-lib/actions/setup-r-dependencies@v2` for the `ci-tests.yml` workflow, which causes some problems:
  - The ubuntu R 3.2.5 job fails because pak is not available for 3.2.5 (and would probably for other reasons as well), but we anyway have the dependency problem with R 3.2.5 mentioned above currently. I.e. we could keep the old steps for this job using conditions (or at some point maybe even a separate workflow file might make sense for such legacy tests).
  - The ubuntu release job fails when trying to run "Check with doc": Unlike the other ubuntu jobs, it tries to `installing *source* package ‘XLConnect’` which fails because something from rJava is missing (see [pipeline](https://github.com/miraisolutions/xlconnect/runs/5290359099?check_suite_focus=true#step:22:33)). **To be investigated**
- Switched to `r-lib/actions/check-r-package@v2` for the `ci-tests.yml` workflow. This didn't introduce any new error and seems to work fine.

After further updates and checks and having another look at the time it takes, it seems there is quite some variability which makes it impossible to tell if the runs are faster than before or not (comparing individual steps could be more useful, but it seems the time didn't change too much overall yet).