### PR TITLE
R dependencies include JDK 11

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, feature/#159-switch-to-rlib-actions-v2 ]
   schedule:
     - cron: '12 23 13,28 * *'
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,7 +76,7 @@ jobs:
           java-version: ${{ matrix.config.java }}
           java-package: jdk
           architecture: x86
-        if: matrix.config.os-name != 'macos'
+        if: matrix.config.os-name != 'macos' && matrix.config.java != 11
       
       - name: Setup java (x64)
         uses: actions/setup-java@v1
@@ -84,7 +84,7 @@ jobs:
           java-version: ${{ matrix.config.java }}
           java-package: jdk
           architecture: x64
-        if: matrix.config.os-name != 'macos'
+        if: matrix.config.os-name != 'macos' && matrix.config.java != 11
 
       - name: Set up R ${{ matrix.config.r-version }}
         uses: r-lib/actions/setup-r@v2
@@ -100,8 +100,9 @@ jobs:
         if: ${{!matrix.config.vignettes}} # covering with / without the var being present
         run: echo 'JAVA_TOOL_OPTIONS="-Dlog4j.formatMsgNoLookups=true"' >> $GITHUB_ENV
 
+      # todo not sure if this is run again during "Install and cache dependencies" before rJava install
       - name: run javareconf # Yes it actually needs JAVA_HOME=$JAVA_HOME, doesn't use actual env vars (!)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.config.java != 11
         run: |
           java -version
           echo java_home:$JAVA_HOME

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, feature/#159-switch-to-rlib-actions-v2 ]
+    branches: [ master ]
   schedule:
     - cron: '12 23 13,28 * *'
 


### PR DESCRIPTION
Avoid installing the JDK when using version 11, as it conflicts with the R dependencies task which also installs it