### PR TITLE
log4j: explicitly set default context factory

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -259,9 +259,9 @@ jobs:
           set -eux -o pipefail
           XLC_JAR_PATH=$(Rscript -e "cat(.libPaths()[1])")/XLConnect/java
           rm -f "$XLC_JAR_PATH"/XLConnect*
-          find "$XLC_JAR_PATH" -maxdepth 1 -type f |\
+          find "$XLC_JAR_PATH" -maxdepth 1 -type f | grep ".jar"|\
           xargs -l sha512sum | sort | awk '{print $1}' > effective_hashes
-          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f |\
+          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f | grep ".jar"|\
           grep -v -E "poi-ooxml-lite|junit|hamcrest" |\
           xargs -l sha512sum | sort | awk '{print $1}' > expected_hashes
           cmp expected_hashes effective_hashes ||\

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -259,9 +259,9 @@ jobs:
           set -eux -o pipefail
           XLC_JAR_PATH=$(Rscript -e "cat(.libPaths()[1])")/XLConnect/java
           rm -f "$XLC_JAR_PATH"/XLConnect*
-          find "$XLC_JAR_PATH" -maxdepth 1 -type f | grep ".jar"|\
+          find "$XLC_JAR_PATH" -maxdepth 1 -type f -name "*.jar"|\
           xargs -l sha512sum | sort | awk '{print $1}' > effective_hashes
-          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f | grep ".jar"|\
+          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f -name "*.jar"|\
           grep -v -E "poi-ooxml-lite|junit|hamcrest" |\
           xargs -l sha512sum | sort | awk '{print $1}' > expected_hashes
           cmp expected_hashes effective_hashes ||\

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 XLConnect News
 --------------
+1.0.8 tbd
+ * avoid log4j2 error on first use (#172) 
 
 1.0.7 2023-01-19
   * Fix issue with loadWorkbook (#181)

--- a/inst/java/log4j2.system.properties
+++ b/inst/java/log4j2.system.properties
@@ -1,0 +1,1 @@
+log4j2.loggerContextFactory=org.apache.logging.log4j.simple.SimpleLoggerContextFactory

--- a/inst/java/log4j2.system.properties
+++ b/inst/java/log4j2.system.properties
@@ -1,1 +1,2 @@
 log4j2.loggerContextFactory=org.apache.logging.log4j.simple.SimpleLoggerContextFactory
+rootLogger.level=OFF


### PR DESCRIPTION
... and set root logger level to `OFF`.
Closes #172 