### PR TITLE
Bugfix/fix tex install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get install -y pandoc
 RUN install2.r --error ggplot2 tinytex
 RUN Rscript -e "{\
     library(tinytex);\
+    tlmgr_update(self=TRUE, all=FALSE);\
     tlmgr_install('datetime');\
-    tlmgr_install('inputenc');\
     tlmgr_install('hyperref');\
     tlmgr_install('url');\
     tlmgr_install('fmtcount');\

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -121,7 +121,6 @@ jobs:
           library(tinytex)
           tlmgr_update(self=TRUE, all=FALSE)
           tlmgr_install('datetime')
-          tlmgr_install('inputenc')
           tlmgr_install('hyperref')
           tlmgr_install('url')
           tlmgr_install('fmtcount')

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -119,7 +119,8 @@ jobs:
         run: |
           pak::pkg_install('tinytex')
           library(tinytex)
-          tlmgr_install('datetime') 
+          tlmgr_update(self=TRUE, all=FALSE)
+          tlmgr_install('datetime')
           tlmgr_install('inputenc')
           tlmgr_install('hyperref')
           tlmgr_install('url')


### PR DESCRIPTION
- To fix the (silently) failing TeX package installations, self-update tlmgr
(as recommended in https://github.com/r-lib/actions/blob/v2-branch/setup-tinytex/README.md#ctan-packages)
- the installation of package _inputenc_ also fails silently, but tests still pass, so leave it out.
