### PR TITLE
Run tests with a readonly library on CRAN

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -250,10 +250,10 @@ jobs:
           rm -f "$XLC_JAR_PATH"/XLConnect*
           find "$XLC_JAR_PATH" -maxdepth 1 -type f -name "*.jar" -exec sha512sum {} + |\
           sort | awk '{print $1}' > effective_hashes
-          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f -name "*.jar" -exec sha512sum {} + |\
+          find "$GITHUB_WORKSPACE"/target/dependency/ -maxdepth 1 -type f -name "*.jar" -exec sha512sum {} + |\
           grep -v -E "poi-ooxml-lite|junit|hamcrest" |\
           sort | awk '{print $1}' > expected_hashes
           cmp expected_hashes effective_hashes ||\
-          (echo "JARs are different!" && ls -la /home/runner/work/xlconnect/xlconnect/target/dependency/ &&\
+          (echo "JARs are different!" && ls -la "$GITHUB_WORKSPACE"/target/dependency/ &&\
           ls -la "$XLC_JAR_PATH" &&\
           exit 1)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -248,11 +248,11 @@ jobs:
           set -eux -o pipefail
           XLC_JAR_PATH=$(Rscript -e "cat(.libPaths()[1])")/XLConnect/java
           rm -f "$XLC_JAR_PATH"/XLConnect*
-          find "$XLC_JAR_PATH" -maxdepth 1 -type f -exec sha512sum {} + |\
-          sort -k2 | awk '{print $1}' > effective_hashes
-          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f -exec sha512sum {} + |\
+          find "$XLC_JAR_PATH" -maxdepth 1 -type f -name "*.jar" -exec sha512sum {} + |\
+          sort | awk '{print $1}' > effective_hashes
+          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f -name "*.jar" -exec sha512sum {} + |\
           grep -v -E "poi-ooxml-lite|junit|hamcrest" |\
-          sort -k2 | awk '{print $1}' > expected_hashes
+          sort | awk '{print $1}' > expected_hashes
           cmp expected_hashes effective_hashes ||\
           (echo "JARs are different!" && ls -la /home/runner/work/xlconnect/xlconnect/target/dependency/ &&\
           ls -la "$XLC_JAR_PATH" &&\

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -196,9 +196,9 @@ jobs:
         if: always()
         run: | 
           echo $(date)
-          cat tests/XLConnect_Unit_Tests.txt || true
+          cat inst/unitTests/resources/XLConnect_Unit_Tests.txt || true
           git clean -fd "*xls*"
-          grep -i "0 errors, 0 failures" tests/XLConnect_Unit_Tests.txt
+          grep -i "0 errors, 0 failures" inst/unitTests/resources/XLConnect_Unit_Tests.txt
         shell: bash
         continue-on-error: true
 
@@ -215,7 +215,7 @@ jobs:
         with:
           name: ${{ matrix.config.os-name }}${{matrix.config.os-version}}-java${{ matrix.config.java }}-R${{ matrix.config.r-version }}-results
           path: |
-            tests/XLConnect_Unit_Tests.*
+            inst/unitTests/resources/XLConnect_Unit_Tests.*
             check/XLConnect.Rcheck/
             !check/XLConnect.Rcheck/**/*.jar
             !check/XLConnect.Rcheck/00_pkg_src/

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -248,11 +248,11 @@ jobs:
           set -eux -o pipefail
           XLC_JAR_PATH=$(Rscript -e "cat(.libPaths()[1])")/XLConnect/java
           rm -f "$XLC_JAR_PATH"/XLConnect*
-          find "$XLC_JAR_PATH" -maxdepth 1 -type f -name "*.jar"|\
-          xargs -l sha512sum | sort | awk '{print $1}' > effective_hashes
-          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f -name "*.jar"|\
+          find "$XLC_JAR_PATH" -maxdepth 1 -type f -exec sha512sum {} + |\
+          sort -k2 | awk '{print $1}' > effective_hashes
+          find /home/runner/work/xlconnect/xlconnect/target/dependency/ -maxdepth 1 -type f -exec sha512sum {} + |\
           grep -v -E "poi-ooxml-lite|junit|hamcrest" |\
-          xargs -l sha512sum | sort | awk '{print $1}' > expected_hashes
+          sort -k2 | awk '{print $1}' > expected_hashes
           cmp expected_hashes effective_hashes ||\
           (echo "JARs are different!" && ls -la /home/runner/work/xlconnect/xlconnect/target/dependency/ &&\
           ls -la "$XLC_JAR_PATH" &&\

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: XLConnect
 Type: Package
 Title: Excel Connector for R
-Version: 1.0.9
+Version: 1.0.10
 Authors@R: c(person("Mirai Solutions GmbH", role = "aut",
                     email = "xlconnect@mirai-solutions.com"),
              person("Martin", "Studer", role = "cre",

--- a/inst/unitTests/runit.writeNamedRegionToFile.R
+++ b/inst/unitTests/runit.writeNamedRegionToFile.R
@@ -29,6 +29,7 @@
 
 test.writeNamedRegionToFile <- function() {
 
+  if(getOption("FULL.TEST.SUITE")) {
 	# Create workbooks
   file.xls <- "testWriteNamedRegionToFileWorkbook.xls"
   file.xlsx <- "testWriteNamedRegionToFileWorkbook.xlsx"
@@ -50,7 +51,7 @@ test.writeNamedRegionToFile <- function() {
             checkEquals(normalizeDataframe(df), res, check.attributes = FALSE, check.names = TRUE)
     }
 
-	if(getOption("FULL.TEST.SUITE")) {
+	
 		# built-in dataset mtcars (*.xls)
 		testDataFrame(file.xls, mtcars)
 		# built-in dataset mtcars (*.xlsx)
@@ -96,7 +97,6 @@ test.writeNamedRegionToFile <- function() {
 		testDataFrame(file.xls, swiss)
 		# built-in dataset swiss (*.xlsx)
 		testDataFrame(file.xlsx, swiss)
-	}
 
 	# custom test dataset
 	cdf <- data.frame(
@@ -161,4 +161,5 @@ test.writeNamedRegionToFile <- function() {
 
   testClearNamedRegions(file.xls, cdf)
   testClearNamedRegions(file.xlsx, cdf)
+  }
 }

--- a/inst/unitTests/runit.writeWorksheetToFile.R
+++ b/inst/unitTests/runit.writeWorksheetToFile.R
@@ -30,6 +30,7 @@
 
 test.writeWorksheetToFile <- function() {
 
+	if(getOption("FULL.TEST.SUITE")) {
 	# Create workbooks
         file.xls <- "testWriteWorksheetToFileWorkbook.xls"
         file.xlsx <- "testWriteWorksheetToFileWorkbook.xlsx"
@@ -51,7 +52,7 @@ test.writeWorksheetToFile <- function() {
                 checkEquals(normalizeDataframe(df), res, check.attributes = FALSE, check.names = TRUE)
         }
 
-	if(getOption("FULL.TEST.SUITE")) {
+	
 		# built-in dataset mtcars (*.xls)
 		testDataFrame(file.xls, mtcars)
 		# built-in dataset mtcars (*.xlsx)
@@ -97,7 +98,6 @@ test.writeWorksheetToFile <- function() {
 		testDataFrame(file.xls, swiss)
 		# built-in dataset swiss (*.xlsx)
 		testDataFrame(file.xlsx, swiss)
-	}
 
 	# custom test dataset
 	cdf <- data.frame(
@@ -139,5 +139,5 @@ test.writeWorksheetToFile <- function() {
 
 	testClearSheets(file.xls, cdf)
 	testClearSheets(file.xlsx, cdf)
-
+	}
 }

--- a/tests/run_tests.R
+++ b/tests/run_tests.R
@@ -92,13 +92,16 @@ runUnitTests <- function() {
 		
 		# Print (summary) test protocol to stdout
 		printTextProtocol(TestResult, showDetails = FALSE)
-		# Write detailed test protocol to text file
-		printTextProtocol(TestResult, showDetails = TRUE, fileName = txtProtocol)
-		# Write HTML protocol
-		printHTMLProtocol(TestResult, fileName = htmlProtocol)
+		# only write results in FULL case, CRAN tries to run with readonly filesystem
+		if (getOption("FULL.TEST.SUITE")) {
+			# Write detailed test protocol to text file
+			printTextProtocol(TestResult, showDetails = TRUE, fileName = txtProtocol)
+			# Write HTML protocol
+			printHTMLProtocol(TestResult, fileName = htmlProtocol)
+		}
 		
 		# Show HTML Test Protocol
-		if (interactive()) { browseURL(url = htmlProtocol) }
+		if (interactive() && getOption("FULL.TEST.SUITE")) { browseURL(url = htmlProtocol) }
 		
 		## Return stop() to cause R CMD check stop in case of
 		##  - failures i.e. FALSE to unit tests or


### PR DESCRIPTION
There is a new CRAN check, running the package check with a readonly R library.
See https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/XLConnect-00check.html and https://github.com/kalibera/cran-checks/tree/master/rlibro/results/XLConnect.

→ Avoid any writes in the non-FULL case, including writing the unit tests results.