### PR TITLE
Bugfix/225 locate simplesimpleloggercontextfactory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: XLConnect
 Type: Package
 Title: Excel Connector for R
-Version: 1.1.0
+Version: 1.1.1.9999
 Authors@R: c(person("Mirai Solutions GmbH", role = "aut",
                     email = "xlconnect@mirai-solutions.com"),
              person("Martin", "Studer", role = "cre",

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 XLConnect News
 --------------
 
+1.1.1.9999 (unreleased)
+
+  * fix #225 (loading simple logging context factory)
+
 1.1.0 2024-08-22
 
   * Support for worksheet scoped names including [#37](https://github.com/miraisolutions/xlconnect/issues/37)

--- a/inst/java/log4j2.system.properties
+++ b/inst/java/log4j2.system.properties
@@ -1,2 +1,3 @@
 log4j2.loggerContextFactory=org.apache.logging.log4j.simple.SimpleLoggerContextFactory
 rootLogger.level=OFF
+log4j.ignoreTCL=true


### PR DESCRIPTION
Closes #225 

added configuration _log4j.ignoreTCL_ as in https://logging.apache.org/log4j/2.x/manual/systemproperties.html#log4j2.ignoreTcl
-- see [comment](https://github.com/miraisolutions/xlconnect/issues/225#issuecomment-2370769108) on issue


(Note: see [source code](https://github.com/apache/logging-log4j2/blob/rel/2.23.1/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java#L51) for effective config name in 2.23.1 - it is not log4j*2*)