### PR TITLE
Update Ubuntu version in CI configuration

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,7 +40,7 @@ jobs:
             vignettes: true
             timezone-name: Asia/Kathmandu
           - os-name: ubuntu # windows-2019, macos-10.15]
-            os-version: "20.04"
+            os-version: "22.04"
             r-version: devel
             java: 17
             vignettes: true


### PR DESCRIPTION
Use 22.04 instead of 20.04

Received an email from GitHub: 

> [...] Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the runner images repository. Please contact GitHub Support if you run into any problems or need help. 