### PR TITLE
Set java.io.tmpdir to R session temporary directory by default; XLConnect 1.2.2 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: XLConnect
 Type: Package
 Title: Excel Connector for R
-Version: 1.2.2.9999
+Version: 1.2.2
 Authors@R: c(person("Mirai Solutions GmbH", role = "aut",
                     email = "xlconnect@mirai-solutions.com"),
              person("Martin", "Studer", role = "cre",

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 XLConnect News
 --------------
 
-1.2.2 2025-05-21
+1.2.2 2025-05-26
   * Set java.io.tmpdir to the R session temp directory by default
   
 1.2.1 2025-04-29

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 XLConnect News
 --------------
 
+1.2.2 2025-05-21
+  * Set java.io.tmpdir to the R session temp directory by default
+  
 1.2.1 2025-04-29
   * Add possibility to configure Apache POI through configurePOI
   * Upgrade POI to 5.4.1

--- a/R/configurePOI.R
+++ b/R/configurePOI.R
@@ -33,8 +33,11 @@ configurePOI <- function(
     zip_max_entry_size = 0xFFFFFFFF,
     zip_max_text_size = 10*1024*1024,
     zip_entry_threshold_bytes = -1L,
-    max_size_byte_array = -1L
+    max_size_byte_array = -1L,
+    java_io_tmpdir = tempdir()
 ) {
+  J("java.lang.System")$setProperty("java.io.tmpdir", java_io_tmpdir)
+  
   ioutils <- J("org.apache.poi.util.IOUtils")
   ioutils$setByteArrayMaxOverride(as.integer(max_size_byte_array))
   

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-# XLConnect 1.2.1
+# XLConnect 1.2.2
 
 ## Test Environments
 
@@ -14,17 +14,17 @@ There were no ERRORs or WARNINGs
 There was 1 INFO:
 
 ```sh
-* checking installed package size ... INFO
-  installed size is 29.0Mb
-  sub-directories of 1Mb or more:
-    java  26.5Mb
+❯ checking installed package size ... NOTE
+    installed size is 28.8Mb
+    sub-directories of 1Mb or more:
+      java  25.8Mb
 ```
 
 Justification: XLConnect uses a Java component which we maintain in a separate project, as well as Apache POI 5.4.x and its dependencies. At install time, the presence of these dependencies in the correct version is checked; if missing, they are downloaded into XLConnect's installation directory. Apache POI 5.4.x is not yet available from major distributions' package managers at the time of writing. In addition, _poi-ooxml-full-<version>.jar_ is required, which is not distributed via package managers. See point 3. of [the POI FAQ](https://poi.apache.org/help/faq.html) for more information.
 
 ## revdepcheck results
 
-We checked 6 reverse dependencies (1 from CRAN + 5 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 5 reverse dependencies (1 from CRAN + 4 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
  * We failed to check 0 packages

--- a/man/configurePOI.Rd
+++ b/man/configurePOI.Rd
@@ -9,7 +9,8 @@ Configures Apache POI and related components.
 \usage{
 configurePOI(zip_max_files = 1000L, zip_min_inflate_ratio = 0.001,
   zip_max_entry_size = 0xFFFFFFFF, zip_max_text_size = 10*1024*1024,
-  zip_entry_threshold_bytes = -1L, max_size_byte_array = -1L)
+  zip_entry_threshold_bytes = -1L, max_size_byte_array = -1L,
+  java_io_tmpdir = tempdir())
 }
 \arguments{
   \item{zip_max_files}{Integer scalar specifying the maximum number of files
@@ -35,6 +36,9 @@ configurePOI(zip_max_files = 1000L, zip_min_inflate_ratio = 0.001,
   this may demand a larger heap space (see option \code{java.parameters}; e.g.
   \code{options(java.parameters = "-Xmx8192m")}. Defaults to -1, which means
   that record-specific limits apply.)}
+  \item{java_io_tmpdir}{Directory to hold POI temporary files and generally any
+  temporary files produced by the Java subprocess. Defaults to the R session
+  temporary directory \code{tempdir()}}
 }
 \details{
 Many of the settings exposed here exist for security reasons to prevent excessive


### PR DESCRIPTION
Set java.io.tmpdir to R session temporary directory by default in `configurePOI`.

Prepare release of XLConnect 1.2.2