### PR TITLE
Fix Codecov integration

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -27,19 +27,19 @@ jobs:
       fail-fast: false
       matrix:
         config: 
-          - os-name: ubuntu # windows-2019, macos-10.15]
+          - os-name: ubuntu
             os-version: latest
             r-version: oldrel
             java: 17 #8
             vignettes: true
             timezone-name: Europe/Zurich
-          - os-name: ubuntu # windows-2019, macos-10.15]
+          - os-name: ubuntu
             os-version: latest
             r-version: release
             java: 21
             vignettes: true
             timezone-name: Asia/Kathmandu
-          - os-name: ubuntu # windows-2019, macos-10.15]
+          - os-name: ubuntu
             os-version: "22.04"
             r-version: devel
             java: 17
@@ -50,8 +50,8 @@ jobs:
             r-version: release
             # java: 13
             vignettes: false
-          - os-name: windows # windows-2019, macos-10.15]
-            os-version: "2019"
+          - os-name: windows
+            os-version: latest
             r-version: release
             java: 8
             vignettes: false

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -204,7 +204,7 @@ jobs:
         if: success() && matrix.config.r-version == 'release' && matrix.config.os-name == 'ubuntu'
         run: |
           library(covr)
-          covr::codecov(function_exclusions=c("onLoad", "onAttach", "xlcEnsureDependencies", "checkSystemPackage"))
+          covr::codecov(function_exclusions=c("onLoad", "onAttach", "xlcEnsureDependencies", "checkSystemPackage"), token = "${{ secrets.CODECOV_TOKEN }}")
         shell: Rscript {0}
       
       - name: Upload check results

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *-Ex.R
 .Rproj.user
 revdep/
+.vscode/


### PR DESCRIPTION
- miraisolutions/meetings#371:  Fixed Codecov integration;  `token` is now required in `covr::codecov`.
see e.g. https://app.codecov.io/gh/miraisolutions/xlconnect/pull/238
compare with the present pull request: https://app.codecov.io/gh/miraisolutions/xlconnect/pull/239

- actions/runner-images#12045  → use latest windows, cleanup ci