### PR TITLE
upgrade devcontainer dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,10 +32,9 @@ RUN R CMD javareconf && \
         stopifnot(as.integer(sub('[.].*', '', version)) >= 25);\
         }"
 
-# XLConnect's Suggests, all needed to build the vignettes and run the checks
-# (ggplot2 and zoo are used in the vignette code chunks). Most are already in
-# the base image, where --skipinstalled turns them into no-ops; listing them all
-# keeps the checks working should the base image stop shipping one. PDF
+# XLConnect's Suggests, needed to build the vignettes and run the checks. Most are already in
+# the base image, but we list them all to 
+# keep the checks working should the base image remove some of them. Note that PDF
 # compaction during `R CMD build` uses the qpdf *system* tool from the base
 # image, not the CRAN package of the same name.
 RUN install2.r --error --skipinstalled ggplot2 lattice testthat withr zoo

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,10 +11,7 @@ FROM rocker/verse:latest
 ENV DEBIAN_FRONTEND=noninteractive
 
 # tidy is needed by `R CMD check --as-cran` to validate the generated HTML.
-# Despite shipping the rJava R package, the base image contains no JDK at all
-# (install_verse.sh installs default-jdk but the subsequent `apt-get
-# autoremove` drops it again), so rJava is unusable until one is installed.
-# Java 25 is the newest JDK covered by the CI matrix.
+# We install JDK 25 as Java 25 is the newest JDK covered by the CI matrix.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gpg \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,10 +2,10 @@
 # which is what the "release" rows of the CI matrix and CRAN check against.
 # Pin to an explicit tag (e.g. rocker/verse:4.6.1) to freeze the R version.
 #
-# The base image already provides pandoc, quarto, TeX Live, the tinytex R
-# package, ghostscript, qpdf, libxml2-dev, libssl-dev, devtools, pak, testthat,
-# ggplot2, withr and the rJava R package, so only what is missing on top of it
-# is installed below.
+# The base image already provides the ghostscript and qpdf system tools, pandoc,
+# quarto, TeX Live, libxml2-dev, libssl-dev and the tinytex, devtools, pak,
+# testthat, ggplot2, withr and rJava R packages, so only what is missing on top
+# of it is installed below.
 FROM rocker/verse:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,8 +32,13 @@ RUN R CMD javareconf && \
         stopifnot(as.integer(sub('[.].*', '', version)) >= 25);\
         }"
 
-# Package dependencies and check tooling not covered by the base image.
-RUN install2.r --error --skipinstalled qpdf withr zoo
+# XLConnect's Suggests, all needed to build the vignettes and run the checks
+# (ggplot2 and zoo are used in the vignette code chunks). Most are already in
+# the base image, where --skipinstalled turns them into no-ops; listing them all
+# keeps the checks working should the base image stop shipping one. PDF
+# compaction during `R CMD build` uses the qpdf *system* tool from the base
+# image, not the CRAN package of the same name.
+RUN install2.r --error --skipinstalled ggplot2 lattice testthat withr zoo
 
 # revdepcheck is not on CRAN, and it pulls in the GitHub-only crancache. The
 # `git::` source makes pak clone over the git protocol instead of going through

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Pin to an explicit tag (e.g. rocker/verse:4.6.1) to freeze the R version.
 #
 # The base image already provides pandoc, quarto, TeX Live, the tinytex R
-# package, ghostscript, qpdf, libxml2-dev, libssl-dev, devtools, testthat,
+# package, ghostscript, qpdf, libxml2-dev, libssl-dev, devtools, pak, testthat,
 # ggplot2, withr and the rJava R package, so only what is missing on top of it
 # is installed below.
 FROM rocker/verse:latest
@@ -37,11 +37,15 @@ RUN R CMD javareconf && \
         }"
 
 # Package dependencies and check tooling not covered by the base image.
-# `remotes` is what `installGithub.r` loads to install from GitHub. The base
-# image ships devtools, which used to depend on remotes but no longer does
-# (devtools 2.5.0 dropped it), so it has to be requested explicitly.
-RUN install2.r --error --skipinstalled qpdf remotes withr zoo
-RUN installGithub.r r-lib/revdepcheck
+RUN install2.r --error --skipinstalled qpdf withr zoo
+
+# revdepcheck is not on CRAN, and it pulls in the GitHub-only crancache. The
+# `git::` source makes pak clone over the git protocol instead of going through
+# the GitHub REST API, whose unauthenticated 60 requests/hour limit is shared
+# per IP and is regularly exhausted on Codespaces hosts. Authenticating is not
+# an option here: Codespaces provides no token during the image build, only
+# inside the running container.
+RUN Rscript -e 'pak::pkg_install("git::https://github.com/r-lib/revdepcheck.git")'
 
 # (more latex libs would be required to include pdf related checks)
 RUN Rscript -e "{\

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update && \
 
 # Point R at the JDK installed above. rJava resolves libjvm through this
 # configuration at load time, so the copy from the base image needs no rebuild.
-# The assertion turns a broken Java setup into a build failure rather than a
-# puzzling runtime error.
+# Then check that Java works from rJava and show the version.
 RUN R CMD javareconf && \
     install2.r --error --skipinstalled rJava && \
     Rscript -e "{\

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,7 +37,10 @@ RUN R CMD javareconf && \
         }"
 
 # Package dependencies and check tooling not covered by the base image.
-RUN install2.r --error --skipinstalled qpdf withr zoo
+# `remotes` is what `installGithub.r` loads to install from GitHub. The base
+# image ships devtools, which used to depend on remotes but no longer does
+# (devtools 2.5.0 dropped it), so it has to be requested explicitly.
+RUN install2.r --error --skipinstalled qpdf remotes withr zoo
 RUN installGithub.r r-lib/revdepcheck
 
 # (more latex libs would be required to include pdf related checks)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,15 +3,18 @@
 # Pin to an explicit tag (e.g. rocker/verse:4.6.1) to freeze the R version.
 #
 # The base image already provides pandoc, quarto, TeX Live, the tinytex R
-# package, ghostscript, qpdf, devtools, testthat, ggplot2 and rJava, so only
-# what is missing on top of it is installed below.
+# package, ghostscript, qpdf, libxml2-dev, libssl-dev, devtools, testthat,
+# ggplot2, withr and the rJava R package, so only what is missing on top of it
+# is installed below.
 FROM rocker/verse:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # tidy is needed by `R CMD check --as-cran` to validate the generated HTML.
-# Java 25 is the newest JDK covered by the CI matrix and supersedes the
-# default-jdk (21) shipped with rocker/verse.
+# Despite shipping the rJava R package, the base image contains no JDK at all
+# (install_verse.sh installs default-jdk but the subsequent `apt-get
+# autoremove` drops it again), so rJava is unusable until one is installed.
+# Java 25 is the newest JDK covered by the CI matrix.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gpg \
@@ -19,11 +22,12 @@ RUN apt-get update && \
         tidy && \
     rm -rf /var/lib/apt/lists/*
 
-# Point R at the new JDK and rebuild rJava from source against it: the copy in
-# the base image is linked against the older default-jdk. The assertion turns a
-# broken Java setup into a build failure rather than a puzzling runtime error.
+# Point R at the JDK installed above. rJava resolves libjvm through this
+# configuration at load time, so the copy from the base image needs no rebuild.
+# The assertion turns a broken Java setup into a build failure rather than a
+# puzzling runtime error.
 RUN R CMD javareconf && \
-    install2.r --error -r https://cloud.r-project.org rJava && \
+    install2.r --error --skipinstalled rJava && \
     Rscript -e "{\
         library(rJava);\
         .jinit();\

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,42 @@
+# rocker/verse:latest tracks the current R release (4.6.1 at the time of writing),
+# which is what the "release" rows of the CI matrix and CRAN check against.
+# Pin to an explicit tag (e.g. rocker/verse:4.6.1) to freeze the R version.
+#
+# The base image already provides pandoc, quarto, TeX Live, the tinytex R
+# package, ghostscript, qpdf, devtools, testthat, ggplot2 and rJava, so only
+# what is missing on top of it is installed below.
 FROM rocker/verse:latest
 
-RUN apt-get update
-RUN apt-get install -y libxml2-dev libssl-dev gpg
-# texlive
-RUN apt-get install -y libqpdf29t64 qpdf ghostscript tidy
-RUN apt-get install -y openjdk-21-jdk-headless
-RUN R CMD javareconf
-# RUN tlmgr install xcolor  # (more latex libs would be required to include pdf related checks)
-RUN install2.r --error devtools rJava testthat zoo qpdf
+ENV DEBIAN_FRONTEND=noninteractive
+
+# tidy is needed by `R CMD check --as-cran` to validate the generated HTML.
+# Java 25 is the newest JDK covered by the CI matrix and supersedes the
+# default-jdk (21) shipped with rocker/verse.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gpg \
+        openjdk-25-jdk-headless \
+        tidy && \
+    rm -rf /var/lib/apt/lists/*
+
+# Point R at the new JDK and rebuild rJava from source against it: the copy in
+# the base image is linked against the older default-jdk. The assertion turns a
+# broken Java setup into a build failure rather than a puzzling runtime error.
+RUN R CMD javareconf && \
+    install2.r --error -r https://cloud.r-project.org rJava && \
+    Rscript -e "{\
+        library(rJava);\
+        .jinit();\
+        version <- .jcall('java/lang/System', 'S', 'getProperty', 'java.version');\
+        cat('rJava runs on Java', version, '\n');\
+        stopifnot(as.integer(sub('[.].*', '', version)) >= 25);\
+        }"
+
+# Package dependencies and check tooling not covered by the base image.
+RUN install2.r --error --skipinstalled qpdf withr zoo
 RUN installGithub.r r-lib/revdepcheck
-RUN apt-get install -y pandoc
-RUN install2.r --error ggplot2 tinytex
+
+# (more latex libs would be required to include pdf related checks)
 RUN Rscript -e "{\
     library(tinytex);\
     tlmgr_update(self=TRUE, all=FALSE);\

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/debian
+// For format details, see https://aka.ms/devcontainer.json. For the full list of
+// config options, see https://containers.dev/implementors/json_reference/
 {
 	"name": "XLC-dev",
 	"build": {


### PR DESCRIPTION
Upgrade devcontainer setup.
- use latest verse image
- trim dependency set
- JDK 25
- install revdepcheck via pak + direct git


Tested locally (podman, ubuntu 24.04) and in codespaces